### PR TITLE
AWS S3: dont include bucket name in filepath

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -45,7 +45,7 @@ func (instance *S3Storage) Save(filename string, bytes []byte) error {
 	reader := ioutil.NopCloser(bt.NewReader(bytes))
 	defer reader.Close()
 
-	objectKey := filepath.Join(*instance.bucket, *instance.path, filename)
+	objectKey := filepath.Join(*instance.path, filename)
 
 	_, err := instance.uploader.Upload(&s3manager.UploadInput{
 		ACL:    aws.String("public-read"),


### PR DESCRIPTION
Hi!

Just found a bug in the filepath that the captured photos get when stored in AWS S3.

This trivial change ensures we don't include the bucket name in objects
stored in the bucket, we only want the optionally configured path
and the filename.

Examples of complete S3 bucket URI w/path and filename:

**Before:** s3://my-timelapse-bucket/my-timelapse-bucket/photos/photo.jpg
**After:** s3://my-timelapse-bucket/photos/photo.jpg